### PR TITLE
remove duplicate rkerberos dependency

### DIFF
--- a/bundler.d/realm_ad_plugin.rb
+++ b/bundler.d/realm_ad_plugin.rb
@@ -1,3 +1,2 @@
 gem 'smart_proxy_realm_ad_plugin'
-gem 'rkerberos'
 gem 'radcli'

--- a/smart_proxy_realm_ad_plugin.gemspec
+++ b/smart_proxy_realm_ad_plugin.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('mocha')
   s.add_development_dependency('test-unit')
-  s.add_development_dependency('rkerberos')
-  s.add_development_dependency('passgen')
-  s.add_development_dependency('radcli')
+  s.add_dependency('rkerberos')
+  s.add_dependency('passgen')
+  s.add_dependency('radcli')
 end


### PR DESCRIPTION
This removes `rkerberos` from the bundler.d extension.

Without this I get the following error on RedHat:

```
Dec 04 15:55:23 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com systemd[1]: Starting Foreman Proxy...
Dec 04 15:55:24 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com smart-proxy[112866]: /usr/share/foreman-proxy/Gemfile.in:8:in `instance_eval': You cannot specify the same gem twice wit
Dec 04 15:55:24 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com smart-proxy[112866]: You specified: rkerberos (>= 0.1.1) and rkerberos (>= 0)
Dec 04 15:55:24 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com smart-proxy[112866]: from (eval):2:in `block in eval_gemfile'
Dec 04 15:55:24 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com smart-proxy[112866]: from /usr/share/foreman-proxy/Gemfile.in:8:in `instance_eval'
Dec 04 15:55:24 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com smart-proxy[112866]: from /usr/share/foreman-proxy/Gemfile.in:8:in `block in eval_gemfile'
Dec 04 15:55:24 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com smart-proxy[112866]: from /usr/share/foreman-proxy/Gemfile.in:7:in `each'
Dec 04 15:55:24 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com smart-proxy[112866]: from /usr/share/foreman-proxy/Gemfile.in:7:in `eval_gemfile'
Dec 04 15:55:24 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com smart-proxy[112866]: from /usr/local/share/gems/gems/bundler-1.8.5/lib/bundler/dsl.rb:32:in `instance_eval'
Dec 04 15:55:24 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com smart-proxy[112866]: from /usr/local/share/gems/gems/bundler-1.8.5/lib/bundler/dsl.rb:32:in `eval_gemfile'
Dec 04 15:55:24 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com smart-proxy[112866]: from /usr/local/share/gems/gems/bundler-1.8.5/lib/bundler/dsl.rb:10:in `evaluate'
Dec 04 15:55:24 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com smart-proxy[112866]: from /usr/share/gems/gems/bundler_ext-0.4.1/lib/bundler_ext/gemfile.rb:46:in `parse'
Dec 04 15:55:24 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com smart-proxy[112866]: from /usr/share/gems/gems/bundler_ext-0.4.1/lib/bundler_ext.rb:14:in `system_require'
Dec 04 15:55:24 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com smart-proxy[112866]: from /usr/share/foreman-proxy/lib/bundler_helper.rb:22:in `require_groups'
Dec 04 15:55:24 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com smart-proxy[112866]: from /usr/share/foreman-proxy/lib/smart_proxy_main.rb:33:in `<top (required)>'
Dec 04 15:55:24 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com smart-proxy[112866]: from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
Dec 04 15:55:24 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com smart-proxy[112866]: from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
Dec 04 15:55:24 tst-timo-16.lxsbx.ka.de.dm-drogeriemarkt.com smart-proxy[112866]: from /usr/share/foreman-proxy/bin/smart-proxy:5:in `<main>'
```