### PR TITLE
use default settings

### DIFF
--- a/lib/smart_proxy_realm_ad/plugin.rb
+++ b/lib/smart_proxy_realm_ad/plugin.rb
@@ -2,10 +2,13 @@ require 'smart_proxy_realm_ad/version'
 
 module Proxy::AdRealm
   class Plugin < Proxy::Provider
+    default_settings :computername_prefix => '', :computername_prefix => false, :computername_use_fqdn => false
+
     load_classes ::Proxy::AdRealm::ConfigurationLoader
     load_dependency_injection_wirings ::Proxy::AdRealm::ConfigurationLoader
 
     validate_presence :realm, :keytab_path, :principal, :domain_controller
+    validate_readable :keytab_path
 
     plugin :realm_ad, ::Proxy::AdRealm::VERSION
   end

--- a/lib/smart_proxy_realm_ad/provider.rb
+++ b/lib/smart_proxy_realm_ad/provider.rb
@@ -18,8 +18,8 @@ module Proxy::AdRealm
       @domain = options[:realm].downcase
       @ou = options[:ou]
       @computername_prefix = options[:computername_prefix]
-      @computername_hash = options.fetch(:computername_hash, false)
-      @computername_use_fqdn = options.fetch(:computername_use_fqdn, false)
+      @computername_hash = options[:computername_hash]
+      @computername_use_fqdn = options[:computername_use_fqdn]
       logger.info 'Proxy::AdRealm: initialize...'
     end
 


### PR DESCRIPTION
This makes use of the `default_settings` DSL to define some default settings. It also ensures, that `keytab_path` is readable.